### PR TITLE
Rename pp-attester to privacypass-attester

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# pp-attester: Privacy Pass Attester
+# privacypass-attester: Privacy Pass Attester
 
-pp-attester is a service that provides [tokens](https://www.ietf.org/archive/id/draft-ietf-privacypass-protocol-14.html) to client able to solve a challenge. It provides an HTTP API to retrieve and validate a challenge,proxying token requests to a Privacy Pass Issuer.
+privacypass-attester is a service that provides [tokens](https://www.ietf.org/archive/id/draft-ietf-privacypass-protocol-14.html) to client able to solve a challenge. It provides an HTTP API to retrieve and validate a challenge,proxying token requests to a Privacy Pass Issuer.
 
 Privacy Pass protocol is defined as an [IETF Draft](https://www.ietf.org/archive/id/draft-ietf-privacypass-protocol-14.html). The attester API is defined ad-hoc, and documented [below][#api-specification].
 
@@ -54,7 +54,7 @@ For Turnstile, the server validates a Turnstile token sent by the client, which 
 This attester is based on Cloudflare Workers. All configuration is held in [wrangler.toml](./wrangler.toml).
 You should update
 
-* `ISSUER_REQUEST_URL` to the URL of your issuer. You can deploy your own issuer with [cloudflare/pp-issuer](https://github.com/cloudflare/pp-issuer).
+* `ISSUER_REQUEST_URL` to the URL of your issuer. You can deploy your own issuer with [cloudflare/privacypass-issuer](https://github.com/cloudflare/privacypass-issuer).
 
 ## API specification
 
@@ -112,7 +112,7 @@ _If the challenge failed_
 
 ## Security Considerations
 
-This software has not been audited. Please use at your sole discretion. With this in mind, pp-attester security relies on the following:
+This software has not been audited. Please use at your sole discretion. With this in mind, privacypass-attester security relies on the following:
 
 * [Privacy Pass](https://www.ietf.org/archive/id/draft-ietf-privacypass-protocol-14.html) protocol, and its implementation in [cloudflare/privacypass-ts](https://github.com/cloudflare/privacypass-ts),
 * [VOPRF](https://datatracker.ietf.org/doc/draft-irtf-cfrg-voprf/) by A. Davidson , A. Faz-Hernandez , N. Sullivan , C. Wood, its implementation in [cloudflare/voprf-ts](https://github.com/cloudflare/voprf-ts),

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,7 +26,7 @@ export default {
 				wranglerConfigEnv: 'dev',
 				mounts: {
 					// Fake service bindings
-					'pp-issuer-dev': {
+					'privacypass-issuer-dev': {
 						script: `export default {
 						  async fetch(request) {
 							return new Response("fake issuer");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-	"name": "pp-attester",
+	"name": "privacypass-attester",
 	"version": "0.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "pp-attester",
+			"name": "privacypass-attester",
 			"version": "0.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "pp-attester",
+	"name": "privacypass-attester",
 	"version": "0.1.0",
 	"type": "module",
 	"main": "dist/worker.mjs",
@@ -10,8 +10,8 @@
 		"Thibault Meunier <thibault@cloudflare.com>"
 	],
 	"license": "Apache-2.0",
-	"homepage": "https://github.com/cloudflare/pp-attester#readme",
-	"repository": "github:cloudflare/pp-attester",
+	"homepage": "https://github.com/cloudflare/privacypass-attester#readme",
+	"repository": "github:cloudflare/privacypass-attester",
 	"scripts": {
 		"build": "tsc && node scripts/cli.js build",
 		"deploy:production": "wrangler publish --no-bundle --env production",

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export interface TurnstileResponse {
 	'cdata'?: string;
 }
 
-// TODO: potentially grab type definitions from @cloudflare/privacypass-ts across all pp- repos
+// TODO: potentially grab type definitions from @cloudflare/privacypass-ts across all privacypass- repos
 export type IssuerConfigurationResponse = {
 	'issuer-request-uri': string;
 	'token-keys': IssuerTokenKey[];


### PR DESCRIPTION
Repositories are going to be renamed. This updates the configuration for deployment